### PR TITLE
REDO-362 Fix for IE10 headline text formatting.

### DIFF
--- a/source/css/scss/app/pages/about.scss
+++ b/source/css/scss/app/pages/about.scss
@@ -5,7 +5,8 @@ a.visitLink:visited {
 
 div.about-headline-wrapper {
 	height: 0;
-
+	position: relative;
+	
 	@media #{$small-only} {
 		padding-bottom: 86.04%;
 	}


### PR DESCRIPTION
@jedlin-kiva Here is a small code change in an effort to contain the headline text within the top container when a user is one IE10. This seemed to do the trick without causing other issues, let me know what you think. If it's good to go just let me know and I'll go through the styleguide release process (I need to get this down). Thanks and happy Friday!
