### PR TITLE
REDO-376 added a medium only media query to fix formatting.......Text…

### DIFF
--- a/source/css/scss/app/pages/about.scss
+++ b/source/css/scss/app/pages/about.scss
@@ -18,6 +18,11 @@ div.about-headline-wrapper {
 div.aboutIntro {
 	padding-top: rem-calc(36);
 
+	@media #{$medium-only} {
+		padding-top: rem-calc(90);
+	}
+
+
 	svg {
 		width: rem-calc(60);
 		height: rem-calc(60);


### PR DESCRIPTION
… is no longer displayed behind image when screen width is between 481-680px

@jedlin-kiva Here i just added a medium-only media query to handle the reported issue. Would you mind taking a look at this? Small change. 
