### PR TITLE
WEBBUG-2440 closed event doesn't fire for dynamic lightboxes, so use …

### DIFF
--- a/source/js/inc/app/lightbox.js
+++ b/source/js/inc/app/lightbox.js
@@ -10,7 +10,7 @@ module.exports = function() {
 	});
 
 	//Allowing scrolling on the body of a page when a lightbox is closed
-	$(document).on('closed.fndtn.reveal', function () {
+	$(document).on('close.fndtn.reveal', function () {
 		$body.css('overflow', 'visible');
 	});
 };


### PR DESCRIPTION
…close instead