### PR TITLE
LW-203 Reduce margin below category description

### DIFF
--- a/source/css/scss/app/pages/finding.scss
+++ b/source/css/scss/app/pages/finding.scss
@@ -221,6 +221,8 @@ $filter-menu-base-width: rem-calc(251);
 	}
 
 	.category-description {
+		margin-bottom: 5px;
+		
 		@include small-text();
 
 		@media #{$large-up} {


### PR DESCRIPTION
@jedlin-kiva The ticket calls for the reduction of padding below the description to 20px. There was no padding-bottom, only a margin-bottom of 20px. Imho, the change to margin-bottom: 5px, looks acceptable.