### PR TITLE
AUTO-134 removing cancel and replace options and <nobr> tags.

### DIFF
--- a/source/_patterns/02-organisms/50-borrower-dashboard/05-auto-repayments.mustache
+++ b/source/_patterns/02-organisms/50-borrower-dashboard/05-auto-repayments.mustache
@@ -17,10 +17,9 @@
 			{{#pausedAutoRepayment}}
 				<div class="panel callout">
 					<div style="float: right; margin-left: 1rem;">
-						<nobr><a class="auto-repayment-reactivate">Activate</a>
-						| <a class="auto-repayment-cancel">Cancel</a></nobr>
+						<a class="auto-repayment-reactivate">Activate</a>
 					</div>
-					Automatic repayments inactive - paused <nobr>{{date}}</nobr><br/>
+					<span>Automatic repayments inactive - paused {{date}}</span><br/>
 					{{#memo}}reason: {{memo}}{{/memo}}
 				</div>
 			{{/pausedAutoRepayment}}
@@ -29,12 +28,11 @@
 		{{#hasAutoRepayment}}
 			<div class="panel">
 				<div style="float: right; margin-left: 1rem;">
-					<nobr><a class="auto-repayment-pause">Pause</a>
-						| <a class="auto-repayment-replace">Replace</a></nobr>
+					<a class="auto-repayment-pause">Pause</a>
 				</div>
 				{{#nextRepayment}}
 					Next payment of <b>${{amount}}</b> will be automatically
-					repaid on <b><nobr>{{date}}</nobr></b>
+					repaid on <b>{{date}}</b>
 				{{/nextRepayment}}
 				{{#preDisbursal}}
 					Enrolled in automatic repayments. Your first repayment


### PR DESCRIPTION
I've removed the "Cancel" and "Replace" options from the mustache file. When I was in there I noticed some <nobr> tags. After doing some research I found out that's a nonstandard tag (see: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/nobr) So I removed those tags and tested in out in my local styleguide and it still looked good to me. Let me know if you have any questions. 