### PR TITLE
LW-1611 fixing hover state of secondary button for mobile.

### DIFF
--- a/source/css/scss/vendor_override/foundation/_buttons.scss
+++ b/source/css/scss/vendor_override/foundation/_buttons.scss
@@ -97,7 +97,7 @@ button.secondary, .button.secondary {
 		color: $kiva-text-dark;
 	}
 
-	.no-touch &:hover {
+	&:hover {
 		border-color: $kiva-accent-blue;
 		color: $kiva-accent-blue;
 	  	box-shadow: 0 1px $kiva-accent-blue;


### PR DESCRIPTION
Removing .no-touch class which gets secondary buttons looking correct on mobile devices on with touch/click interaction.