### PR TITLE
cash-1471 styleguide closing of notice isn't working, this adds a nee…

### DIFF
--- a/source/_patterns/02-organisms/00-global/04-gdpr-notice.mustache
+++ b/source/_patterns/02-organisms/00-global/04-gdpr-notice.mustache
@@ -4,7 +4,14 @@
 			We use cookies to improve your experience and enable the functionality and security of this site.
 			By continuing to use this site, you agree to the use of these cookies.
 			For more information or to change your cookie preferences please see our <a href="{{legal_cookie_url}}" target="_blank">cookie policy</a>.
-			<button class="setting button close-button">Sounds good</button>
+			<div class="notice-header">
+				<button 
+					class="setting button close-button"
+					aria-label="Close"
+				>
+				Sounds good
+				</button>
+			</div>
 		</div>
 	</div>
 </div>


### PR DESCRIPTION
…ded class for the click to close identifier

click-close is looking for the following identifier to be triggered: 
(".notice-header .close-button").one("click",function(){e("click-close")

So this PR wraps the <button class=".close-button"> with a <div class="notice-header">, which should correctly trigger the close function that's in place. 