### PR TITLE
cash-1630 hiding the EOY appeal banner on /my/borrower page

### DIFF
--- a/source/css/scss/app/pages/borrower-dashboard.scss
+++ b/source/css/scss/app/pages/borrower-dashboard.scss
@@ -2,6 +2,10 @@
 @import '../../font-vars';
 
 .borrower-dashboard-main {
+	.sitewide-appeal-wrapper {
+		display: none;
+	}
+	
 	.loan-info {
 		margin-bottom: 2rem;
 	}


### PR DESCRIPTION
cash-1630, this hides the EOY appeal banner on the borrower dashboard page (/my/borrower). 