### PR TITLE
cash-1630 more targeted css to hide EOYappealBanner on borrowerDashboard

### DIFF
--- a/source/css/scss/app/pages/borrower-dashboard.scss
+++ b/source/css/scss/app/pages/borrower-dashboard.scss
@@ -1,11 +1,15 @@
 @import '../../settings';
 @import '../../font-vars';
 
-.borrower-dashboard-main {
+.borrowerDashboard_endorsements,
+.borrowerDashboard_home,
+.borrowerDashboard_transactions {
 	.sitewide-appeal-wrapper {
 		display: none;
 	}
-	
+}
+
+.borrower-dashboard-main {
 	.loan-info {
 		margin-bottom: 2rem;
 	}


### PR DESCRIPTION
This more specific style should correctly hide the EOY appeal banner on the /my/borrower page.