### PR TITLE
Fixed spacing after inputs in MG settings page

### DIFF
--- a/source/_patterns/02-organisms/22-settings/01-auto-deposit-settings.mustache
+++ b/source/_patterns/02-organisms/22-settings/01-auto-deposit-settings.mustache
@@ -119,21 +119,21 @@
 			{{/legacy}}
 			<label>Donation to Kiva</label>
 		</div>
-		{{^legacy}}
-			{{#is_subscriber}}
-				{{#selected_category}}
-					<div class="category-selection">
-						<label for="mg-category-select">{{mgCategorySelectHeading}}</label>
-						<select id="mg-category-select">
-							{{#mg_category_options}}
-								<option value="{{value}}" {{#selected}}selected="selected"{{/selected}}>{{title}}</option>
-							{{/mg_category_options}}
-						</select>
-					</div>
-				{{/selected_category}}
-			{{/is_subscriber}}
-		{{/legacy}}
 	</div>
+	{{^legacy}}
+		{{#is_subscriber}}
+			{{#selected_category}}
+				<div class="category-selection">
+					<label for="mg-category-select">{{mgCategorySelectHeading}}</label>
+					<select id="mg-category-select">
+						{{#mg_category_options}}
+							<option value="{{value}}" {{#selected}}selected="selected"{{/selected}}>{{title}}</option>
+						{{/mg_category_options}}
+					</select>
+				</div>
+			{{/selected_category}}
+		{{/is_subscriber}}
+	{{/legacy}}	
 	{{^legacy}}
 		<div class="total-amount-minimum">
 			<input type="text"


### PR DESCRIPTION
Fixes bug with a lot of extra space after inputs on MG settings page. This will fix the spacing, unfortunately, moving the select out of its parent div modifies the css (which is in kiva repo)...

This looks better than it is currently. Looks great after a corresponding commit to fix css in kiva/kiva. But we can release without waiting for that