### PR TITLE
grow-523 mustache conditionals for hide borrower details exp

### DIFF
--- a/source/_patterns/01-molecules/15-loan-sections/06-loan-details.mustache
+++ b/source/_patterns/01-molecules/15-loan-sections/06-loan-details.mustache
@@ -1,5 +1,5 @@
 <section class="loan-details">
-    <div class="ac-title ac-container" data-kv-accordion aria-controls="ac-loan-details-body{{#right}}-right{{/right}}" aria-expanded="true" kvtrackevent="Borrower Profile|click-accordion|Loan details">
+    <div class="ac-title ac-container" data-kv-accordion aria-controls="ac-loan-details-body{{#right}}-right{{/right}}" aria-expanded="{{#bp_hide_loan_details_exp}}false{{/bp_hide_loan_details_exp}}{{^bp_hide_loan_details_exp}}true{{/bp_hide_loan_details_exp}}" kvtrackevent="Borrower Profile|click-accordion|Loan details">
         <h2>
             Loan details
             <span class="ac-dropdown-icon">
@@ -9,7 +9,7 @@
             </span>
         </h2>
     </div>
-    <div class="ac-body" id="ac-loan-details-body{{#right}}-right{{/right}}" aria-hidden="false">
+    <div class="ac-body" id="ac-loan-details-body{{#right}}-right{{/right}}" aria-hidden="{{#bp_hide_loan_details_exp}}true{{/bp_hide_loan_details_exp}}{{^bp_hide_loan_details_exp}}false{{/bp_hide_loan_details_exp}}">
         <div class="loan-term print-5 columns">
             <svg class="icon icon-recycle"><use xlink:href="#icon-recycle"></use></svg>
 			<h2><a kvtrackevent="Borrower Profile|click-loan details" href="#" id="repayment-term" class="black-underlined" data-reveal-id="repayment-term-lightbox">Loan length</a>:</h2>

--- a/source/_patterns/01-molecules/15-loan-sections/07-lenders-teams.mustache
+++ b/source/_patterns/01-molecules/15-loan-sections/07-lenders-teams.mustache
@@ -1,4 +1,4 @@
-<article class="ac-body" id="ac-lenders-teams-body" aria-hidden="false">
+<article class="ac-body" id="ac-lenders-teams-body" aria-hidden="{{#bp_hide_loan_details_exp}}true{{/bp_hide_loan_details_exp}}{{^bp_hide_loan_details_exp}}false{{/bp_hide_loan_details_exp}}">
 
 	{{! ------------------------- Lenders section -------------------------------- }}
 

--- a/source/_patterns/01-molecules/15-loan-sections/19-about-zip-business.mustache
+++ b/source/_patterns/01-molecules/15-loan-sections/19-about-zip-business.mustache
@@ -1,5 +1,5 @@
 <section class="about-zip">
-	<div class="ac-title ac-container" data-kv-accordion aria-controls="ac-about-zip-body" aria-expanded="true">
+	<div class="ac-title ac-container" data-kv-accordion aria-controls="ac-about-zip-body" aria-expanded="{{#bp_hide_loan_details_exp}}false{{/bp_hide_loan_details_exp}}{{^bp_hide_loan_details_exp}}true{{/bp_hide_loan_details_exp}}">
 		<h2>
 			<div class="ac-title-text">
 				About {{businessName}}
@@ -11,7 +11,7 @@
 			</span>
 		</h2>
 	</div>
-	<div class="ac-body" id="ac-about-zip-body" aria-hidden="false">
+	<div class="ac-body" id="ac-about-zip-body" aria-hidden="{{#bp_hide_loan_details_exp}}true{{/bp_hide_loan_details_exp}}{{^bp_hide_loan_details_exp}}false{{/bp_hide_loan_details_exp}}">
 		<p>
 		{{#industry}}
 			Industry: {{industry}}

--- a/source/_patterns/01-molecules/15-loan-sections/40-lenders-teams-wrapper.mustache
+++ b/source/_patterns/01-molecules/15-loan-sections/40-lenders-teams-wrapper.mustache
@@ -1,5 +1,5 @@
 <section class="lenders-teams" id="lenders-teams">
-	<div class="ac-title ac-container" data-kv-accordion aria-controls="ac-lenders-teams-body" aria-expanded="{{#bp_hide_loan_details_exp}}false{{/bp_hide_loan_details_exp}}{{^bp_hide_loan_details_exp}}true{{/bp_hide_loan_details_exp}}">
+	<div class="ac-title ac-container" data-kv-accordion aria-controls="ac-lenders-teams-body" aria-expanded="true">
 		<h2>
 			Lenders and lending teams
             <span class="ac-dropdown-icon">

--- a/source/_patterns/01-molecules/15-loan-sections/40-lenders-teams-wrapper.mustache
+++ b/source/_patterns/01-molecules/15-loan-sections/40-lenders-teams-wrapper.mustache
@@ -1,5 +1,5 @@
 <section class="lenders-teams" id="lenders-teams">
-	<div class="ac-title ac-container" data-kv-accordion aria-controls="ac-lenders-teams-body" aria-expanded="true">
+	<div class="ac-title ac-container" data-kv-accordion aria-controls="ac-lenders-teams-body" aria-expanded="{{#bp_hide_loan_details_exp}}false{{/bp_hide_loan_details_exp}}{{^bp_hide_loan_details_exp}}true{{/bp_hide_loan_details_exp}}">
 		<h2>
 			Lenders and lending teams
             <span class="ac-dropdown-icon">

--- a/source/_patterns/04-pages/05-borrower-profile.mustache
+++ b/source/_patterns/04-pages/05-borrower-profile.mustache
@@ -67,7 +67,7 @@
 				<!-- Teams and Lenders -->
 				<hr class="line-break"/>
 				<section class="lenders-teams" id="lenders-teams">
-					<div class="ac-title ac-container" data-kv-accordion aria-controls="ac-lenders-teams-body" aria-expanded="true" kvtrackevent="Borrower Profile|click-accordion|Lenders and lending teams">
+					<div class="ac-title ac-container" data-kv-accordion aria-controls="ac-lenders-teams-body" aria-expanded="{{#bp_hide_loan_details_exp}}false{{/bp_hide_loan_details_exp}}{{^bp_hide_loan_details_exp}}true{{/bp_hide_loan_details_exp}}" kvtrackevent="Borrower Profile|click-accordion|Lenders and lending teams">
 						<h2>
 							Lenders and lending teams
 							<span class="ac-dropdown-icon">


### PR DESCRIPTION
Styleguide changes for [grow-523](https://kiva.atlassian.net/browse/GROW-523)

If user is in the experiment then we collapse all menus on borrower page except loan-story & why-special, otherwise load default behavior.