### PR TITLE
ML2-310 removing match svg from mustache files

### DIFF
--- a/source/_patterns/02-organisms/04-loancards/00-loancard-listing.mustache
+++ b/source/_patterns/02-organisms/04-loancards/00-loancard-listing.mustache
@@ -63,7 +63,6 @@
 			{{#is_matched}}
 				{{^is_ended}}
 					<div class="matching-message">
-						<svg class="icon icon-match"><use xlink:href="#icon-match"/></svg>
 						<span>{{matching_text}}</span>
 					</div>
 				{{/is_ended}}

--- a/source/_patterns/02-organisms/04-loancards/10-loancard-2.mustache
+++ b/source/_patterns/02-organisms/04-loancards/10-loancard-2.mustache
@@ -62,7 +62,6 @@
 		<div class="matching-line">
 			{{#is_matched}}
 				{{^is_ended}}
-					<svg class="icon icon-match"><use xlink:href="#icon-match"/></svg>
 					<span>{{matching_text}}</span>
 				{{/is_ended}}
 			{{/is_matched}}


### PR DESCRIPTION
This is a portion of the code for ML2-310. 

In these changes I'm removing the '2x' matching svg from a couple mustache files. This change is in conjunction with flexible match ratios being displayed in text now. ie '3x matching by LOANMATCHERNAME"