### PR TITLE
fix: Core-211 updating the loan tag text shown on the /lend page

### DIFF
--- a/source/_patterns/02-organisms/05-filters/06-tags-filter.mustache
+++ b/source/_patterns/02-organisms/05-filters/06-tags-filter.mustache
@@ -6,7 +6,7 @@
 
 <h3 class="filter medium-notouch">
 	Tags
-	<div class="subtext">Added by lenders like you. Learn more at the <a href="https://www.kiva.org/team/loan_taggers" target="_blank">Loan Taggers team</a>.</div>
+	<div class="subtext">Added by lenders like you.</div>
 </h3>
 
 <div class="filter-component-container">


### PR DESCRIPTION
[Core-211](https://kiva.atlassian.net/browse/CORE-211)

I've updated the loan tags text on the /lend page, we just shortened it to remove the mention of the loan taggers team. 