### PR TITLE
fix: Core-231 removing match-icon and taking matchRatio into account …

### DIFF
--- a/source/_patterns/01-molecules/40-portfolio/07-my-loans-table-row.mustache
+++ b/source/_patterns/01-molecules/40-portfolio/07-my-loans-table-row.mustache
@@ -3,9 +3,12 @@
 		<img src="{{image.url}}" data-interchange="{{#image.sizes}}[{{url}}, ({{size}})],{{/image.sizes}}">
 	</a>
 	{{#matchedLoan}}
-		<svg class="icon icon-match">
-			<use xlink:href="#icon-match"/>
-		</svg>
+		{{#matchRatio}}
+			<p>{{matchRatio}}x matched</p>
+		{{/matchRatio}}
+		{{^matchRatio}}
+			<p>Matched</p>
+		{{/matchRatio}}
 	{{/matchedLoan}}
 	{{#dedication}}
 		{{^toKiva}}


### PR DESCRIPTION
…in messaging

[Core-231](https://kiva.atlassian.net/browse/CORE-231) 

- Styleguide portion of Core-231, Removed the match-icon, taking the matchRatio into account if it's available.

