### PR TITLE
Core-231 decreasing size of matched text in the user's loans table on…

### DIFF
--- a/source/_patterns/01-molecules/40-portfolio/07-my-loans-table-row.mustache
+++ b/source/_patterns/01-molecules/40-portfolio/07-my-loans-table-row.mustache
@@ -4,7 +4,9 @@
 	</a>
 	{{#matchedLoan}}
 		{{#matchRatio}}
-			<p class="matched-text">{{matchRatio}}x matched</p>
+			<p class="matched-text">
+				{{matchRatio}}x matched
+			</p>
 		{{/matchRatio}}
 		{{^matchRatio}}
 			<p class="matched-text">

--- a/source/_patterns/01-molecules/40-portfolio/07-my-loans-table-row.mustache
+++ b/source/_patterns/01-molecules/40-portfolio/07-my-loans-table-row.mustache
@@ -4,10 +4,12 @@
 	</a>
 	{{#matchedLoan}}
 		{{#matchRatio}}
-			<p>{{matchRatio}}x matched</p>
+			<p class="matched-text">{{matchRatio}}x matched</p>
 		{{/matchRatio}}
 		{{^matchRatio}}
-			<p>Matched</p>
+			<p class="matched-text">
+				Matched
+			</p>
 		{{/matchRatio}}
 	{{/matchedLoan}}
 	{{#dedication}}

--- a/source/css/scss/app/pages/portfolio.scss
+++ b/source/css/scss/app/pages/portfolio.scss
@@ -671,6 +671,10 @@ table.loans-table {
 		vertical-align: top;
 		padding-right: 0;
 
+		p.matched-text {
+			font-size: 0.75rem;
+		}
+
 		&:first-child {
 			padding-left: 0;
 			min-width: rem-calc(50);


### PR DESCRIPTION
… /portfolio/loans

Core-231

Through discussion in the ticket we've decided to decrease the size of the matching text in the /portfolio/loans table to 12px/0.75rem. 

<img width="997" alt="Screen Shot 2021-11-02 at 3 53 04 PM" src="https://user-images.githubusercontent.com/1521381/139963828-4a0f851a-deb5-42bd-bd49-b137e574469e.png">


