### PR TITLE
fix: core-217 updating loan bookmarking icon from star to new bookmar…

### DIFF
--- a/source/_patterns/00-atoms/04-images/05-icons.mustache
+++ b/source/_patterns/00-atoms/04-images/05-icons.mustache
@@ -22,6 +22,20 @@
 	</li>
 
 	<li class="icon">
+		<div class="sg-element-group-description">Bookmark icon</div>
+		<svg class="icon icon-bookmark">
+			<use xlink:href="#icon-bookmark"/>
+		</svg>
+	</li>
+
+	<li class="icon">
+		<div class="sg-element-group-description">Bookmark icon(filled)</div>
+		<svg class="icon icon-bookmark-filled">
+			<use xlink:href="#icon-bookmark-filled"/>
+		</svg>
+	</li>
+
+	<li class="icon">
 		<div class="sg-element-group-description">Half star icon</div>
 		<svg class="icon icon-half-star">
 			<use xlink:href="#icon-half-star"/>

--- a/source/_patterns/01-molecules/30-loans/11-loan-image-footer.mustache
+++ b/source/_patterns/01-molecules/30-loans/11-loan-image-footer.mustache
@@ -13,6 +13,6 @@
 		<a kvtrackevent="Lending|click-Favorite star|Favorite|undefined|true" {{^is_touch}}data-tooltip aria-haspopup="true"{{/is_touch}} title="Star this loan to find it quickly later. You can view and manage your starred loans in the ‘Lend’ tab above." href="#" class="{{^is_touch}}has-tip tip-left{{/is_touch}} favorite-link{{#is_favorite}} is-favorite{{/is_favorite}}">
 	{{/is_loan_card_view}}
 
-		<svg class="icon icon-star"><use xlink:href="#icon-star"/></svg>
+		<svg class="icon icon-bookmark"><use xlink:href="#icon-bookmark"/></svg>
 	</a>
 {{/can_favorite}}

--- a/source/_patterns/01-molecules/30-loans/11-loan-image-footer.mustache
+++ b/source/_patterns/01-molecules/30-loans/11-loan-image-footer.mustache
@@ -13,6 +13,6 @@
 		<a kvtrackevent="Lending|click-Favorite star|Favorite|undefined|true" {{^is_touch}}data-tooltip aria-haspopup="true"{{/is_touch}} title="Star this loan to find it quickly later. You can view and manage your starred loans in the ‘Lend’ tab above." href="#" class="{{^is_touch}}has-tip tip-left{{/is_touch}} favorite-link{{#is_favorite}} is-favorite{{/is_favorite}}">
 	{{/is_loan_card_view}}
 
-		<svg class="icon icon-bookmark"><use xlink:href="#icon-bookmark"/></svg>
+		<svg class="icon icon-star"><use xlink:href="#icon-star"/></svg>
 	</a>
 {{/can_favorite}}

--- a/source/_patterns/02-organisms/04-loancards/10-loancard-2.mustache
+++ b/source/_patterns/02-organisms/04-loancards/10-loancard-2.mustache
@@ -11,8 +11,9 @@
 
 		{{#can_favorite}}
 			<div class="favorite-star-wrapper">
-				<a kvtrackevent="Lending|click-Favorite star|Favorite|undefined|true" title="Star this loan to find it quickly later. You can view and manage your starred loans in the ‘Lend’ tab above." href="#" class="favorite-link{{#is_favorite}} is-favorite{{/is_favorite}}">
-					<svg class="icon icon-star"><use xlink:href="#icon-star"/></svg>
+				<a kvtrackevent="Lending|click-Favorite star|Favorite|undefined|true" title="Save this loan to find it quickly later. You can view and manage your starred loans in the ‘Lend’ tab above." href="#" class="favorite-link{{#is_favorite}} is-favorite{{/is_favorite}}">
+					{{#is_favorite}}<svg class="icon icon-bookmark-filled"><use xlink:href="#icon-bookmark-filled"/></svg>{{/is_favorite}}
+					{{^is_favorite}}<svg class="icon icon-bookmark"><use xlink:href="#icon-bookmark"/></svg>{{/is_favorite}}
 				</a>
 			</div>
 		{{/can_favorite}}

--- a/source/_patterns/02-organisms/04-loancards/10-loancard-2.mustache
+++ b/source/_patterns/02-organisms/04-loancards/10-loancard-2.mustache
@@ -11,7 +11,7 @@
 
 		{{#can_favorite}}
 			<div class="favorite-star-wrapper">
-				<a kvtrackevent="Lending|click-Favorite star|Favorite|undefined|true" title="Save this loan to find it quickly later. You can view and manage your starred loans in the ‘Lend’ tab above." href="#" class="favorite-link{{#is_favorite}} is-favorite{{/is_favorite}}">
+				<a kvtrackevent="Lending|click-Favorite star|Favorite|undefined|true" title="Save this loan to find it quickly later. You can view and manage your saved loans in the ‘Lend’ tab above." href="#" class="favorite-link{{#is_favorite}} is-favorite{{/is_favorite}}">
 					{{#is_favorite}}<svg class="icon icon-bookmark-filled"><use xlink:href="#icon-bookmark-filled"/></svg>{{/is_favorite}}
 					{{^is_favorite}}<svg class="icon icon-bookmark"><use xlink:href="#icon-bookmark"/></svg>{{/is_favorite}}
 				</a>

--- a/source/css/scss/app/loancards-2.scss
+++ b/source/css/scss/app/loancards-2.scss
@@ -73,23 +73,19 @@ $loan-card-border: 1px solid $kiva-stroke-gray;
 		  	bottom: 0;
 		  	right: 0;
 		 	border: none;
+			background-color: #FFFFFF;
+			border-radius: 50%;
+			margin-right: 0.25rem;
+			margin-bottom: 0.25rem;
 		}
 
-		.icon-star {
+		.icon-bookmark,
+		.icon-bookmark-filled {
 		  	height: 2rem;
 		  	width: 2rem;
-		  	fill: transparent;
-		  	color: $white;
-		  	opacity: 0.6;
-		  	background-color: #484848;
-		  	padding: .5rem;
+		  	padding: 0.5rem;
 		  	vertical-align: bottom;
 		}
-	}
-
-	.is-favorite .icon-star {
-		opacity: 1;
-		color: $vivid-yellow;
 	}
 
 	.loan-card-2-details-wrap {

--- a/source/images/icons.min/bookmark-filled.svg
+++ b/source/images/icons.min/bookmark-filled.svg
@@ -1,0 +1,3 @@
+<svg width="14" height="18" viewBox="0 0 14 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12 0H2C0.9 0 0 0.9 0 2V18L7 15L14 18V2C14 0.9 13.1 0 12 0Z" fill="#2B7C5F"/>
+</svg>

--- a/source/images/icons.min/bookmark.svg
+++ b/source/images/icons.min/bookmark.svg
@@ -1,0 +1,3 @@
+<svg width="14" height="18" viewBox="0 0 14 18" xmlns="http://www.w3.org/2000/svg">
+<path d="M12 0H2C0.9 0 0 0.9 0 2V18L7 15L14 18V2C14 0.9 13.1 0 12 0ZM12 15L7 12.82L2 15V3C2 2.45 2.45 2 3 2H11C11.55 2 12 2.45 12 3V15Z" fill="#2B7C5F"/>
+</svg>


### PR DESCRIPTION
…k.svg

[CORE-217](https://kiva.atlassian.net/browse/CORE-217)

Updated the old favorite icon (star) with the new bookmark icon. This change is included on all old loan cards coming from styleguide.

**check it out:** 
<img width="1014" alt="Screen Shot 2022-01-15 at 8 38 17 AM" src="https://user-images.githubusercontent.com/1521381/149627727-dfb3c8ab-ab7f-4b93-97da-8d5f3ecf3ccc.png">

I figured I could get this out and tested for Tuesday's release and the we can have a discussion on Tuesday about cleaning up the old favoriting functionality on the old borrower profile, if needed.