### PR TITLE
fix: core-218 updating Starred loans -> Saved loans

### DIFF
--- a/source/_patterns/02-organisms/08-header/03-lend-menu.mustache
+++ b/source/_patterns/02-organisms/08-header/03-lend-menu.mustache
@@ -33,12 +33,12 @@
 	                <a href="#" data-kv-accordion aria-controls="lend-menu-personalized-panel" aria-expanded="false" class="section-title">My Kiva<svg class="icon icon-small-chevron-mobile"><use xlink:href="#icon-small-chevron-mobile" /></svg></a>
 	                <ul id="lend-menu-personalized-panel" aria-hidden="true">
 						{{#has_favorites}}
-							<li class="favorites-href-in-nav"><a kvtrackevent="TopNav|click-Lend-Favorites" href="{{favorites_href}}">Starred loans</a></li>
-							<li class="no-favorites-href-in-nav hide"><a kvtrackevent="TopNav|click-Lend-Favorites" href="#" class="disabled">Starred loans</a></li>
+							<li class="favorites-href-in-nav"><a kvtrackevent="TopNav|click-Lend-Favorites" href="{{favorites_href}}">Saved loans</a></li>
+							<li class="no-favorites-href-in-nav hide"><a kvtrackevent="TopNav|click-Lend-Favorites" href="#" class="disabled">Saved loans</a></li>
 						{{/has_favorites}}
 						{{^has_favorites}}
-							<li class="no-favorites-href-in-nav"><a kvtrackevent="TopNav|click-Lend-Favorites" href="#" class="disabled">Starred loans</a></li>
-							<li class="favorites-href-in-nav hide"><a kvtrackevent="TopNav|click-Lend-Favorites" href="{{favorites_href}}">Starred loans</a></li>
+							<li class="no-favorites-href-in-nav"><a kvtrackevent="TopNav|click-Lend-Favorites" href="#" class="disabled">Saved loans</a></li>
+							<li class="favorites-href-in-nav hide"><a kvtrackevent="TopNav|click-Lend-Favorites" href="{{favorites_href}}">Saved loans</a></li>
 						{{/has_favorites}}
 						{{#has_saved_searches}}
                             <li class="lend-menu-searches-li-mobile">
@@ -100,12 +100,12 @@
 					<div class="section-title">My Kiva</div>
 					<ul>
 						{{#has_favorites}}
-							<li class="favorites-href-in-nav"><a kvtrackevent="TopNav|click-Lend-Favorites" href="{{favorites_href}}">Starred loans</a></li>
-							<li class="no-favorites-href-in-nav hide"><a kvtrackevent="TopNav|click-Lend-Favorites" href="#" class="disabled">Starred loans</a></li>
+							<li class="favorites-href-in-nav"><a kvtrackevent="TopNav|click-Lend-Favorites" href="{{favorites_href}}">Saved loans</a></li>
+							<li class="no-favorites-href-in-nav hide"><a kvtrackevent="TopNav|click-Lend-Favorites" href="#" class="disabled">Saved loans</a></li>
 						{{/has_favorites}}
 						{{^has_favorites}}
-							<li class="no-favorites-href-in-nav"><a kvtrackevent="TopNav|click-Lend-Favorites" href="#" class="disabled">Starred loans</a></li>
-							<li class="favorites-href-in-nav hide"><a kvtrackevent="TopNav|click-Lend-Favorites" href="{{favorites_href}}">Starred loans</a></li>
+							<li class="no-favorites-href-in-nav"><a kvtrackevent="TopNav|click-Lend-Favorites" href="#" class="disabled">Saved loans</a></li>
+							<li class="favorites-href-in-nav hide"><a kvtrackevent="TopNav|click-Lend-Favorites" href="{{favorites_href}}">Saved loans</a></li>
 						{{/has_favorites}}
 						{{#has_saved_searches}}
 							<li class="lend-menu-searches-li-desktop">
@@ -147,3 +147,5 @@
                     {{/saved_searches}}
                 </ul>
             </div>
+	</div>
+</div>

--- a/source/_patterns/02-organisms/08-header/03-lend-menu.mustache
+++ b/source/_patterns/02-organisms/08-header/03-lend-menu.mustache
@@ -147,5 +147,3 @@
                     {{/saved_searches}}
                 </ul>
             </div>
-	</div>
-</div>


### PR DESCRIPTION
[Core-218](https://kiva.atlassian.net/browse/CORE-218)

There will be more changes coming related to this ticket in the other repos, this covers the changes for /kiva/styleguide.

Text change from "Starred loans" -> "Saved loans"