### PR TITLE
fix: bring back simple category grid template which is still in use i…

### DIFF
--- a/source/_patterns/02-organisms/07-categorycards/07-simple-category-grid.json
+++ b/source/_patterns/02-organisms/07-categorycards/07-simple-category-grid.json
@@ -1,0 +1,46 @@
+{
+    "categories-primary" : [
+        {
+            "name": "Women",
+            "src": "../../images/category/women.jpg",
+            "retina-src": "../../images/category/women-retina.jpg",
+            "href": "##"
+        },
+        {
+            "name": "Agriculture",
+            "src": "../../images/category/agriculture.jpg",
+            "retina-src": "../../images/category/agriculture-retina.jpg",
+            "href": "##"
+        },
+        {
+            "name": "Education",
+            "src": "../../images/category/education.jpg",
+            "retina-src": "../../images/category/education-retina.jpg",
+            "href": "##"
+        },
+        {
+            "name": "Health",
+            "src": "../../images/category/health.jpg",
+            "retina-src": "../../images/category/health-retina.jpg",
+            "href": "##"
+        },
+        {
+            "name": "Single Parents",
+            "src": "../../images/category/single.jpg",
+            "retina-src": "../../images/category/single-retina.jpg",
+            "href": "##"
+        },
+        {
+            "name": "Shelter",
+            "src": "../../images/category/shelter.jpg",
+            "retina-src": "../../images/category/shelter-retina.jpg",
+            "href": "##"
+        },
+        {
+            "name": "Food",
+            "src": "../../images/category/food.jpg",
+            "retina-src": "../../images/category/food-retina.jpg",
+            "href": "##"
+        }
+    ]
+}

--- a/source/_patterns/02-organisms/07-categorycards/07-simple-category-grid.mustache
+++ b/source/_patterns/02-organisms/07-categorycards/07-simple-category-grid.mustache
@@ -1,0 +1,20 @@
+<div class="basic-category-grid">
+	<div class="frame">
+		<h1 class="impact">Browse loans by category</h1>
+		<ul class="category-card-grid small-block-grid-2 medium-block-grid-3">
+			{{#categories-primary}}
+				<li>{{> 02-organisms/07-categorycards/00-category-card}}</li>
+			{{/categories-primary}}
+			<li class="more-categories-card"><a kvtrackevent="Lending|click-Category-Tile|More" href="{{all-categories-href}}">
+				<div class="category-card solid-color-card">
+					<div class="category-card-overlay">
+						<div class="color-card-center">
+							<p class="category-card-title">View all</p>
+						</div>
+					</div>
+				</div>
+			</a></li>
+		</ul>
+		<p class="featured">By lending as little as $25, you can help people around the world create opportunity for themselves and their communities. <br><a href="{{get-started-href}}" kvtrackevent="Lending|click-Category-Subhead|Get-Started">Get started</a></p>
+	</div>
+</div>


### PR DESCRIPTION
…n the monolith

This was removed here https://github.com/kiva/styleguide/pull/904